### PR TITLE
Budget Editing Modal Basis

### DIFF
--- a/Server/routes/api/addCategory.js
+++ b/Server/routes/api/addCategory.js
@@ -1,0 +1,60 @@
+const express = require('express')
+const router = express.Router();
+const { getSupabaseClientWithAuth } = require('../../services/supabase')
+
+router.post('/', function (req, response, next) {
+    Promise.resolve()
+        .then(async function() {
+            const { category, sbAccessToken, userID } = req.body;
+
+            // Normalize category name
+            const normalizedCategory = 
+                category.charAt(0).toUpperCase() + category.slice(1).toLowerCase();
+
+            const supabase = getSupabaseClientWithAuth(sbAccessToken);
+
+            // Check if category already exists for the user
+            const { data: selectUserBudgetsMatchingCategory, error: selectUserBudgetsError } = await supabase
+                .from("userBudgets")
+                .select("category")
+                .eq("id", userID)
+                .eq("category", normalizedCategory);
+            
+            // If category exists, return conflict response
+            if (selectUserBudgetsMatchingCategory && selectUserBudgetsMatchingCategory.length > 0) {
+                return response.status(409).json({ 
+                    message: 'Category already exists for this user' 
+                });
+            }
+
+            if (selectUserBudgetsError){
+                return response.status(400).json({
+                    message: `this error occurred while checking if category already exists for user in database: ${selectUserBudgetsError}`
+                })
+            }
+
+            // If no error and no existing category, insert new category
+            const { error: insertError } = await supabase
+                .from("userBudgets")
+                .insert({ 
+                    id: userID, 
+                    category: normalizedCategory 
+                });
+
+            // Handle insert error
+            if (insertError) {
+                console.error('Error inserting category:', insertError);
+                return response.status(500).json({ 
+                    message: 'Failed to add category' 
+                });
+            }
+
+            // Success response
+            response.status(201).json({ 
+                message: 'Category added successfully' 
+            });
+        })
+        .catch(next);
+});
+
+module.exports = router;

--- a/Server/server.js
+++ b/Server/server.js
@@ -46,6 +46,9 @@ app.use('/api/delete_expense', apiDeleteExpenseRouter);
 const apiCreateBankAccountRouter = require('./routes/api/createBankAccount');
 app.use('/api/create_bank_account', apiCreateBankAccountRouter);
 
+const apiAddCategoryRouter = require('./routes/api/addCategory');
+app.use('/api/add_category', apiAddCategoryRouter);
+
 // Global error handler
 app.use((err, req, res, next) => {
   console.error(err.stack);

--- a/Web/src/components/AddCategoryModal.jsx
+++ b/Web/src/components/AddCategoryModal.jsx
@@ -1,0 +1,118 @@
+import React, { useState } from 'react';
+import { 
+    Modal, 
+    ModalOverlay, 
+    ModalContent, 
+    ModalHeader, 
+    ModalFooter, 
+    ModalBody, 
+    ModalCloseButton,
+    Button,
+    Input,
+    FormControl,
+    FormLabel,
+    useToast
+} from '@chakra-ui/react';
+import supabase from '../supabaseClient';
+
+const AddCategoryModal = ({ isOpenAddCategoryModal, setIsOpenAddCategoryModal }) => {
+    const [categoryName, setCategoryName] = useState('');
+    const [error, setError] = useState('');
+    const toast = useToast();
+
+    const handleClose = () => {
+        setIsOpenAddCategoryModal(false);
+        setCategoryName(''); // Clear input when modal closes
+        setError('');
+    };
+
+    const handleInputChange = (e) => {
+        const value = e.target.value;
+        
+        // Check if all characters are letters or spaces
+        const isValid = value.split('').every(char => 
+            (char >= 'a' && char <= 'z') || 
+            (char >= 'A' && char <= 'Z') ||
+            char === ' '
+        );
+        
+        if (isValid) {
+            setCategoryName(value);
+            setError('');
+        } else {
+            setError('Category name can only contain letters');
+        }
+    };
+
+    const handleAdd = async () => {
+        const sbAccessToken = localStorage.getItem('sb_access_token');
+        const { data: { user } } = await supabase.auth.getUser()
+        const userID = user?.id || '';
+        const response = await fetch(`${import.meta.env.VITE_API_URL}/add_category`,{
+            method: "POST",
+            headers: {
+            "Content-Type": "application/json"
+            },
+            body: JSON.stringify({ category: categoryName, sbAccessToken, userID }),
+        });
+        handleClose();
+        if (!response.ok) {
+            const data = await response.json();
+            toast({
+                title: "Error Adding Category",
+                description: data.message || "Failed to add category",
+                status: "error",
+                duration: 3000,
+                isClosable: true,
+                position: "bottom"
+            });
+            return;
+        }
+        const data = await response.json();
+        toast({
+            title: "Category Added",
+            description: data.message,
+            status: "success",
+            duration: 3000,
+            isClosable: true,
+            position: "bottom"
+        });
+    };
+
+    return (
+        <Modal isOpen={isOpenAddCategoryModal} onClose={handleClose} isCentered>
+            <ModalOverlay />
+            <ModalContent>
+                <ModalHeader>Add Category</ModalHeader>
+                <ModalCloseButton />
+                <ModalBody>
+                    <FormControl>
+                        <FormLabel>Category Name</FormLabel>
+                        <Input 
+                        placeholder="Enter category (e.g., Food, Utilities)" 
+                        value={categoryName}
+                        onChange={handleInputChange}
+                        />
+                    </FormControl>
+                </ModalBody>
+                <ModalFooter>
+                <Button 
+                    colorScheme="blue" 
+                    mr={3} 
+                    onClick={handleClose}
+                >
+                    Cancel
+                </Button>
+                <Button 
+                    colorScheme="blue"
+                    onClick={handleAdd} 
+                >
+                    Add
+                </Button>
+                </ModalFooter>
+            </ModalContent>
+        </Modal>
+    );
+};
+
+export default AddCategoryModal;

--- a/Web/src/components/BudgetCategoryCard.jsx
+++ b/Web/src/components/BudgetCategoryCard.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import {
+    Box,
+    VStack,
+    Flex,
+    Text,
+    Progress
+} from "@chakra-ui/react"
+
+const BudgetCategoryCard = ({
+    category,
+    budget,
+    spent,
+}) => {
+    const percentage = (spent / budget) * 100;
+    return (
+        <Box p={4} borderWidth="1px" borderRadius="md">
+            <VStack align="stretch" spacing={4}>
+                <Flex justify="space-between">
+                    <Text fontWeight="bold">{category}</Text>
+                    <Text>${spent} / ${budget}</Text>
+                </Flex>
+                <Progress value={percentage} colorScheme={percentage > 90 ? "red" : "green"} size="sm" />
+                <Text fontSize="sm" color={percentage > 90 ? "red.500" : "green.500"}>
+                    {percentage.toFixed(1)}% used
+                </Text>
+            </VStack>
+        </Box>
+    );
+};
+
+export default BudgetCategoryCard;

--- a/Web/src/components/EditTotalBudget.jsx
+++ b/Web/src/components/EditTotalBudget.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { 
+    Flex, 
+    Text, 
+    Input, 
+    FormControl 
+} from '@chakra-ui/react';
+import { useBudget } from '../context/budgetContext';
+
+const EditTotalBudget = ({ handleBudgetChange, potentialTotalBudget }) => {
+    const { totalBudget, setTotalBudget } = useBudget();
+
+    return (
+        <Flex align="center" justifySelf={'center'} gap={4}>
+            <Text fontWeight={3} fontSize={14}>Total</Text>
+            <FormControl>
+                <Input 
+                type="text" 
+                value={potentialTotalBudget}
+                onChange={handleBudgetChange}
+                w={70}
+                />
+            </FormControl>
+        </Flex>
+    );
+};
+
+export default EditTotalBudget;

--- a/Web/src/components/ModalCategoryBudgetSlider.jsx
+++ b/Web/src/components/ModalCategoryBudgetSlider.jsx
@@ -38,15 +38,16 @@ const ModalCategoryBudgetSlider = ({ category }) => {
 
     return (
         <Flex 
-        align="center" 
+        align="center"
+        justifySelf={"center"} 
         gap={8} 
         w="full" 
         maxW="xl" 
         p={4}
         >
-        <Box w="32" textAlign="left">
-            <Text fontWeight="medium">{category}</Text>
-        </Box>
+        <Flex w="32" align='center' >
+            <Text fontWeight="light" fontSize={14}>{category}</Text>
+        </Flex>
         
         <Box flex="1" position="relative">
             <Box
@@ -70,6 +71,7 @@ const ModalCategoryBudgetSlider = ({ category }) => {
             max={totalBudget}
             step={1}
             onChange={handleSliderChange}
+            mt={2}
             >
                 <SliderTrack>
                     <SliderFilledTrack />

--- a/Web/src/components/ModalCategoryBudgetSlider.jsx
+++ b/Web/src/components/ModalCategoryBudgetSlider.jsx
@@ -1,4 +1,3 @@
-// modalCategoryBudgetSlider.jsx
 import React, { useState, useEffect } from 'react';
 import {
     Slider,

--- a/Web/src/components/ModalCategoryBudgetSlider.jsx
+++ b/Web/src/components/ModalCategoryBudgetSlider.jsx
@@ -1,0 +1,84 @@
+// modalCategoryBudgetSlider.jsx
+import React, { useState, useEffect } from 'react';
+import {
+    Slider,
+    SliderTrack,
+    SliderFilledTrack,
+    SliderThumb,
+    Box,
+    Text,
+    Flex
+} from '@chakra-ui/react';
+import { useBudget } from '../context/budgetContext';
+
+const ModalCategoryBudgetSlider = ({ category }) => {
+    const { allocatedBudget, setAllocatedBudget, totalBudget, reset } = useBudget();
+    const [sliderValue, setSliderValue] = useState(0);
+    
+    const handleSliderChange = (newValue) => {
+        // Calculate how much this slider's change would affect the total allocated budget
+        const budgetDifference = newValue - sliderValue;
+        const newAllocatedBudget = allocatedBudget + budgetDifference;
+        
+        // Only allow the change if it wouldn't exceed the total budget
+        if (newAllocatedBudget <= totalBudget) {
+            setSliderValue(newValue);
+            setAllocatedBudget(newAllocatedBudget);
+        } else {
+            // If the change would exceed the budget, set the slider to the maximum allowed value
+            const maxAllowedValue = sliderValue + (totalBudget - allocatedBudget);
+            setSliderValue(maxAllowedValue);
+            setAllocatedBudget(totalBudget);
+        }
+    };
+
+    useEffect(() => {
+            setSliderValue(0);
+    },[reset]);
+
+    return (
+        <Flex 
+        align="center" 
+        gap={8} 
+        w="full" 
+        maxW="xl" 
+        p={4}
+        >
+        <Box w="32" textAlign="left">
+            <Text fontWeight="medium">{category}</Text>
+        </Box>
+        
+        <Box flex="1" position="relative">
+            <Box
+            position="absolute"
+            top="-6"
+            left={`${(sliderValue / totalBudget) * 100}%`}
+            transform="translateX(-50%)"
+            bg="transparent"
+            px={2}
+            py={1}
+            borderRadius="md"
+            boxShadow="sm"
+            >
+                <Text fontSize="sm">{sliderValue}</Text>
+            </Box>
+            
+            {/* Slider component */}
+            <Slider
+            value={sliderValue}
+            min={0}
+            max={totalBudget}
+            step={1}
+            onChange={handleSliderChange}
+            >
+                <SliderTrack>
+                    <SliderFilledTrack />
+                </SliderTrack>
+                <SliderThumb />
+            </Slider>
+        </Box>
+        </Flex>
+    );
+};
+
+export default ModalCategoryBudgetSlider;

--- a/Web/src/context/budgetContext.jsx
+++ b/Web/src/context/budgetContext.jsx
@@ -1,0 +1,37 @@
+import { createContext, useContext, useState } from 'react';
+
+const BudgetContext = createContext();
+
+export const BudgetProvider = ({ children, initTotalBudget }) => {
+    const [allocatedBudget, setAllocatedBudget] = useState(0);
+    const [totalBudget, setTotalBudget] = useState(initTotalBudget);
+    const [reset, setReset] = useState(false);
+
+    const updateTotalBudget = (newTotal) => {
+            if (newTotal < allocatedBudget){
+                setAllocatedBudget(0);
+                setReset(!reset);
+            }
+    };
+    
+    return (
+        <BudgetContext.Provider 
+            value={{ 
+                allocatedBudget, 
+                setAllocatedBudget,
+                totalBudget, 
+                setTotalBudget, 
+                reset 
+            }}>
+                {children}
+        </BudgetContext.Provider>
+    );
+};
+
+export const useBudget = () => {
+    const context = useContext(BudgetContext);
+    if (context === undefined) {
+        throw new Error('useBudget must be used within a BudgetProvider');
+    }
+    return context;
+};

--- a/Web/src/main.jsx
+++ b/Web/src/main.jsx
@@ -4,13 +4,16 @@ import App from './App.tsx'
 import './index.css'
 import { QuickstartProvider } from './context/index.tsx'
 import { ThemeProvider as ThemeProviderForMUI } from './context/themeContext.jsx';
+import { BudgetProvider } from './context/budgetContext.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <ThemeProviderForMUI>
-      <QuickstartProvider>
-        <App />
-      </QuickstartProvider>
-    </ThemeProviderForMUI>
+    <BudgetProvider initTotalBudget={1000}>
+      <ThemeProviderForMUI>
+        <QuickstartProvider>
+          <App />
+        </QuickstartProvider>
+      </ThemeProviderForMUI>
+    </BudgetProvider>
   </StrictMode>,
 )

--- a/Web/src/pages/Budget.jsx
+++ b/Web/src/pages/Budget.jsx
@@ -1,16 +1,43 @@
 
 // src/pages/Budget.jsx
 import React, {useState} from 'react';
-import { Box, SimpleGrid, Progress, Text, VStack, useColorModeValue, Button, Flex, Modal, ModalOverlay, ModalContent, ModalHeader, ModalFooter, ModalBody, ModalCloseButton } from '@chakra-ui/react';
+//chakra ui imports
+import { 
+    Box, 
+    SimpleGrid, 
+    Progress, 
+    Text, 
+    VStack, 
+    useColorModeValue, 
+    Button, 
+    Flex, 
+    Modal, 
+    ModalOverlay, 
+    ModalContent, 
+    ModalHeader, 
+    ModalFooter, 
+    ModalBody, 
+    ModalCloseButton 
+} from '@chakra-ui/react';
+//faker import for fake data
 import { faker } from '@faker-js/faker';
-import { FaPlus, FaChartBar } from 'react-icons/fa';
-import PageHeader from '../components/PageHeader';
-import DashboardCard from '../components/DashboardCard';
-import BudgetWindowSelect from '../components/BudgetWindowSelect';
-import { FaRegEdit } from "react-icons/fa";
-import ModalCategoryBudgetSlider from '../components/ModalCategoryBudgetSlider';
+//icon imports
+import { 
+    FaPlus, 
+    FaChartBar, 
+    FaRegEdit 
+} from 'react-icons/fa';
+//context import for budget details
 import { useBudget } from '../context/budgetContext';
+//component imports (sorted alphabetically)
+import AddCategoryModal from '../components/AddCategoryModal';
+import BudgetCategoryCard from '../components/BudgetCategoryCard';
+import BudgetWindowSelect from '../components/BudgetWindowSelect';
+import DashboardCard from '../components/DashboardCard';
 import EditTotalBudget from '../components/EditTotalBudget';
+import ModalCategoryBudgetSlider from '../components/ModalCategoryBudgetSlider';
+import PageHeader from '../components/PageHeader';
+
 
 const categories = ['Food', 'Transportation', 'Entertainment', 'Utilities', 'Shopping'];
 
@@ -24,6 +51,9 @@ function Budget() {
   const {setAllocatedBudget, totalBudget} = useBudget();
 
   const [potentialTotalBudget, setPotentialTotalBudget] = useState(totalBudget.toString());
+
+  //variable necessary for holding open/closed state of the add category modal
+  const [isOpenAddCategoryModal, setIsOpenAddCategoryModal] = useState(false);
 
   const handleEditButtonClick = () => {
       setIsEditModalOpen(true);
@@ -88,7 +118,7 @@ function Budget() {
           <Text fontSize="xl" fontWeight="bold">Budget Breakdown</Text>
           <Box>
             <Button leftIcon={<FaRegEdit />} colorScheme="blue" width={{base:'43px', megasmall:'auto'}} mr={3} onClick={handleEditButtonClick}>Edit</Button>
-            <Button leftIcon={<FaPlus />} colorScheme="blue" width={{base:'86px',megasmall:'auto'}} >Add Category</Button>
+            <Button leftIcon={<FaPlus />} colorScheme="blue" width={{base:'86px',megasmall:'auto'}} onClick={() => {setIsOpenAddCategoryModal(true)}}>Add Category</Button>
           </Box>
         </Flex>
         <SimpleGrid columns={{ base: 1, md: 2 }} spacing={6}>
@@ -96,23 +126,19 @@ function Budget() {
             const spent = faker.number.int({ min: 100, max: 1000 });
             const budget = faker.number.int({ min: spent, max: spent + 500 });
             const percentage = (spent / budget) * 100;
-            return (
-              <Box key={category} p={4} borderWidth="1px" borderRadius="md">
-                <VStack align="stretch" spacing={4}>
-                  <Flex justify="space-between">
-                    <Text fontWeight="bold">{category}</Text>
-                    <Text>${spent} / ${budget}</Text>
-                  </Flex>
-                  <Progress value={percentage} colorScheme={percentage > 90 ? "red" : "green"} size="sm" />
-                  <Text fontSize="sm" color={percentage > 90 ? "red.500" : "green.500"}>
-                    {percentage.toFixed(1)}% used
-                  </Text>
-                </VStack>
-              </Box>
+
+            return(
+              <BudgetCategoryCard
+                key={category} 
+                budget={budget}
+                spent={spent}
+                category={category}
+              />
             );
           })}
         </SimpleGrid>
       </Box>
+      {/* modal for editing budgets (I will probably make this its own component down the line) */}
       <Modal isOpen={isEditModalOpen} onClose={handleCloseModal} size="2xl" isCentered>
           <ModalOverlay />
           <ModalContent>
@@ -137,6 +163,11 @@ function Budget() {
               </ModalFooter>
           </ModalContent>
       </Modal>
+
+      <AddCategoryModal 
+          isOpenAddCategoryModal={isOpenAddCategoryModal}
+          setIsOpenAddCategoryModal={setIsOpenAddCategoryModal}    
+      />
     </Box>
   );
 }

--- a/Web/src/pages/Budget.jsx
+++ b/Web/src/pages/Budget.jsx
@@ -8,6 +8,8 @@ import PageHeader from '../components/PageHeader';
 import DashboardCard from '../components/DashboardCard';
 import BudgetWindowSelect from '../components/BudgetWindowSelect';
 import { FaRegEdit } from "react-icons/fa";
+import ModalCategoryBudgetSlider from '../components/ModalCategoryBudgetSlider';
+import { useBudget } from '../context/budgetContext';
 
 const categories = ['Food', 'Transportation', 'Entertainment', 'Utilities', 'Shopping'];
 
@@ -18,12 +20,18 @@ function Budget() {
   const [budgetWindow, setBudgetWindow] = useState('Year');
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
 
+  const {setAllocatedBudget} = useBudget();
+
   const handleEditButtonClick = () => {
       setIsEditModalOpen(true);
+
   };
 
   const handleCloseModal = () => {
-      setIsEditModalOpen(false);
+      setIsEditModalOpen(false);  // close the modal (duh)
+      setAllocatedBudget(0); // make sure the allocated budget gets reset so upon trying to edit again it doesn't lock u at 0 for the sliders
+      // in the future will need to not set allocated budget to 0 but set it whatever it was before according to the database
+      // will also need a way of resetting each slider to their original values, probably with context and a new useEffect (within the slider component) with something from the context in the dependency array
   };
 
   const handleApplyChanges = () => {
@@ -90,16 +98,15 @@ function Budget() {
           })}
         </SimpleGrid>
       </Box>
-      <Modal isOpen={isEditModalOpen} onClose={handleCloseModal} size="4xl">
+      <Modal isOpen={isEditModalOpen} onClose={handleCloseModal} size="2xl" isCentered>
           <ModalOverlay />
           <ModalContent>
-              <ModalHeader>Edit Budget</ModalHeader>
+              <ModalHeader textAlign={"center"}>{`${budgetWindow}ly Budget`}</ModalHeader>
               <ModalCloseButton />
               <ModalBody>
                   {/* I will add self-balancing sliders here for each category */}
-                  <Text>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Quis maiores quasi numquam sequi asperiores illum enim distinctio eum consequatur repudiandae et, voluptates rerum possimus aliquid dolor perspiciatis pariatur ipsum iusto?</Text>
-                  <Text>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Quis maiores quasi numquam sequi asperiores illum enim distinctio eum consequatur repudiandae et, voluptates rerum possimus aliquid dolor perspiciatis pariatur ipsum iusto?</Text>
-                  <Text>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Quis maiores quasi numquam sequi asperiores illum enim distinctio eum consequatur repudiandae et, voluptates rerum possimus aliquid dolor perspiciatis pariatur ipsum iusto?</Text>
+                  <ModalCategoryBudgetSlider  category='Eating Out' />
+                  <ModalCategoryBudgetSlider  category='Groceries' />
               </ModalBody>
               <ModalFooter>
                 <Button colorScheme="blue" mr={3} onClick={handleCloseModal}>

--- a/Web/src/pages/Budget.jsx
+++ b/Web/src/pages/Budget.jsx
@@ -10,6 +10,7 @@ import BudgetWindowSelect from '../components/BudgetWindowSelect';
 import { FaRegEdit } from "react-icons/fa";
 import ModalCategoryBudgetSlider from '../components/ModalCategoryBudgetSlider';
 import { useBudget } from '../context/budgetContext';
+import EditTotalBudget from '../components/EditTotalBudget';
 
 const categories = ['Food', 'Transportation', 'Entertainment', 'Utilities', 'Shopping'];
 
@@ -20,7 +21,9 @@ function Budget() {
   const [budgetWindow, setBudgetWindow] = useState('Year');
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
 
-  const {setAllocatedBudget} = useBudget();
+  const {setAllocatedBudget, totalBudget} = useBudget();
+
+  const [potentialTotalBudget, setPotentialTotalBudget] = useState(totalBudget.toString());
 
   const handleEditButtonClick = () => {
       setIsEditModalOpen(true);
@@ -32,11 +35,23 @@ function Budget() {
       setAllocatedBudget(0); // make sure the allocated budget gets reset so upon trying to edit again it doesn't lock u at 0 for the sliders
       // in the future will need to not set allocated budget to 0 but set it whatever it was before according to the database
       // will also need a way of resetting each slider to their original values, probably with context and a new useEffect (within the slider component) with something from the context in the dependency array
+      setPotentialTotalBudget(totalBudget.toString());
   };
 
   const handleApplyChanges = () => {
       //will add functionality to this later
       //probably will involve 
+  };
+
+  const handleBudgetChange = (e) => {
+      const value = Math.floor(Number(e.target.value))
+
+      // Only update budget if value is a positive integer
+      if (/^\d*$/.test(value) && Number(value) > 0) {
+          setPotentialTotalBudget(e.target.value);
+      }else{
+          setPotentialTotalBudget('');
+      }
   };
 
   return (
@@ -104,6 +119,10 @@ function Budget() {
               <ModalHeader textAlign={"center"}>{`${budgetWindow}ly Budget`}</ModalHeader>
               <ModalCloseButton />
               <ModalBody>
+                  <EditTotalBudget 
+                      handleBudgetChange={handleBudgetChange}
+                      potentialTotalBudget={potentialTotalBudget}    
+                  />
                   {/* I will add self-balancing sliders here for each category */}
                   <ModalCategoryBudgetSlider  category='Eating Out' />
                   <ModalCategoryBudgetSlider  category='Groceries' />


### PR DESCRIPTION
---
name: Budget Editing Modal Basis 🚀
about: Adding budget editing functionality with self-balancing sliders in a Chakra modal.
title: "[FEATURE] Implement budget breakdown modal with self-balancing sliders 🌟"
labels: ''
assignees: ''

---

**Related Issue(s)** 🔗
N/A

**Acceptance Test(s)** ✔️
1. cd into Web
2. npm run dev
3. navigate to budget page
4. click edit button
5. verify sliders balance appropriately
6. verify input for total is able to be changed and wiped clean (applying does nothing yet so dont worry about that)

**Implementation Notes** 📝
- used chakra modal
- modal has time frame indicator
- Added EditTotalBudget.jsx component to handle editing the total budget (duh)
- Added ModalCategoryBudgetSlider.jsx component to handle slider functionality and b/c I'm going to need multiple so better have a reusable component
- Added budgetContext.jsx to share important values between components for slider balancing functionality and eventually for other budget editing related things.

**Related PR(s)** 🔄
budget/budget-edit-button-for-budget-breadown branch pr

**Checklist:** ✅
- [ ✅] My code follows the style guidelines of this project
- [ ✅] I have performed a self-review of my own code
- [ ✅] I have commented my code, particularly in hard-to-understand areas
- [ ✅] I have made corresponding changes to the documentation
- [ ✅] My changes generate no new warnings
- [ ✅] I have added tests that prove my fix is effective or that my feature works
- [ ✅] New and existing unit tests pass locally with my changes
- [ ✅] Any dependent changes have been merged and published in downstream modules

**Screenshots** 📸
![Screenshot 2025-01-22 234450](https://github.com/user-attachments/assets/42bdbf33-1a05-490c-ba21-0ae4e0acd244)


**Additional Context** ➕
Add any other context about the pull request here.