### PR TITLE
feat: Editing Budgets

### DIFF
--- a/Server/routes/api/changeBudgets.js
+++ b/Server/routes/api/changeBudgets.js
@@ -1,0 +1,42 @@
+const express = require('express')
+const router = express.Router();
+const { getSupabaseClientWithAuth } = require('../../services/supabase')
+
+router.post('/', function (req, response, next) {
+    Promise.resolve()
+        .then(async function() {
+            const { newTotal, newCategoryToBudgetDictionary, sbAccessToken, userID } = req.body;
+
+            const supabase = getSupabaseClientWithAuth(sbAccessToken);
+
+            const { error: upsertExistingUserBudgetTotalError } = await supabase
+                    .from("userBudgetTotals")
+                    .upsert({
+                        id: userID,
+                        budget_total: newTotal
+                    });
+                
+            if (upsertExistingUserBudgetTotalError){
+                return response.status(400).json({ message: `Error occurred on upsert for new budget total for user: ${upsertExistingUserBudgetTotalError}` });
+            }
+            
+            const categoryBudgetsToUpsert = Object.entries(newCategoryToBudgetDictionary).map(([category, budget]) => ({
+                id: userID,
+                category: category,
+                budget: budget
+            }));
+
+            const { error: categoryBudgetsUpsertError } = await supabase
+                .from("userBudgets")
+                .upsert(categoryBudgetsToUpsert);
+            
+            if (categoryBudgetsUpsertError){
+                return response.status(400).json({ message: `Error occurred trying to upsert new budgets for categories: ${categoryBudgetsUpsertError}` });
+            }
+
+            return response.status(200).json({ message: "Successfully upserted both total budget and budgets for specific categories" })
+        })
+        .catch(next);
+});
+
+module.exports = router;

--- a/Server/routes/api/changeBudgets.js
+++ b/Server/routes/api/changeBudgets.js
@@ -14,7 +14,9 @@ router.post('/', function (req, response, next) {
                     .upsert({
                         id: userID,
                         budget_total: newTotal
-                    });
+                    },
+                    { onConflict: 'id' }
+                    );
                 
             if (upsertExistingUserBudgetTotalError){
                 return response.status(400).json({ message: `Error occurred on upsert for new budget total for user: ${upsertExistingUserBudgetTotalError}` });
@@ -28,7 +30,7 @@ router.post('/', function (req, response, next) {
 
             const { error: categoryBudgetsUpsertError } = await supabase
                 .from("userBudgets")
-                .upsert(categoryBudgetsToUpsert);
+                .upsert(categoryBudgetsToUpsert, { onConflict: ['id', 'category'] });
             
             if (categoryBudgetsUpsertError){
                 return response.status(400).json({ message: `Error occurred trying to upsert new budgets for categories: ${categoryBudgetsUpsertError}` });

--- a/Server/routes/api/getBudgetDetails.js
+++ b/Server/routes/api/getBudgetDetails.js
@@ -13,6 +13,15 @@ router.post('/', function (req, response, next) {
 
             const supabase = getSupabaseClientWithAuth(sbAccessToken);
 
+            const { data: selectUserBudgetTotal, error: selectUserBudgetTotalError } = await supabase
+                .from("userBudgetTotals")
+                .select("budget_total")
+                .eq("id", userID);
+            
+            if (selectUserBudgetTotalError){
+                return response.status(400).json({ message: `Error occurred trying to get the users total budget: ${selectUserBudgetTotalError}` });
+            }
+
             const { data: selectUserBudgetDetails, error: selectUserBudgetDetailsError } = await supabase
                 .from("userBudgets")
                 .select("category, budget")
@@ -23,7 +32,11 @@ router.post('/', function (req, response, next) {
             };
 
             if (selectUserBudgetDetails && selectUserBudgetDetails.length > 0){
-                return response.status(200).json({ budgetDetails: selectUserBudgetDetails });
+                const budgetObject = selectUserBudgetDetails.reduce((acc, item) => ({
+                    ...acc,
+                    [item.category]: item.budget
+                }), {});
+                return response.status(200).json({ budgetDetails: budgetObject, budgetTotal: selectUserBudgetTotal?.length > 0 ? selectUserBudgetTotal[0].budget_total : 0 });
             }else{
                 return response.status(404).json({ message: 'Could not find budget details for user' })
             };

--- a/Server/server.js
+++ b/Server/server.js
@@ -52,6 +52,9 @@ app.use('/api/add_category', apiAddCategoryRouter);
 const apiGetBudgetDetailsRouter = require('./routes/api/getBudgetDetails');
 app.use('/api/get_budget_details', apiGetBudgetDetailsRouter);
 
+const apiChangeBudgets = require('./routes/api/changeBudgets');
+app.use('/api/change_budgets', apiChangeBudgets);
+
 // Global error handler
 app.use((err, req, res, next) => {
   console.error(err.stack);

--- a/Web/src/components/ModalCategoryBudgetSlider.jsx
+++ b/Web/src/components/ModalCategoryBudgetSlider.jsx
@@ -11,8 +11,16 @@ import {
 import { useBudget } from '../context/budgetContext';
 
 const ModalCategoryBudgetSlider = ({ category, budget }) => {
-    const { allocatedBudget, setAllocatedBudget, potentialTotalBudget } = useBudget();
+    const [hasMounted, setHasMounted] = useState(false);
+    const { allocatedBudget, setAllocatedBudget, potentialTotalBudget, setPotentialCategoryToBudgetDictionary } = useBudget();
     const [sliderValue, setSliderValue] = useState(budget);
+
+    const editPotentialBudgetForCategory = (newValue) => {
+        setPotentialCategoryToBudgetDictionary(prev => ({
+            ...prev,
+            [category]: newValue
+        }));
+    };
     
     const handleSliderChange = (newValue) => {
         // Calculate how much this slider's change would affect the total allocated budget
@@ -21,22 +29,29 @@ const ModalCategoryBudgetSlider = ({ category, budget }) => {
         
         if (Number(newValue) < Number(sliderValue)) {
             setSliderValue(newValue);
+            editPotentialBudgetForCategory(newValue);
             setAllocatedBudget(newAllocatedBudget);
             return;
         }
         // Only allow the change if it wouldn't exceed the total budget
         if (newAllocatedBudget <= Number(potentialTotalBudget)) {
             setSliderValue(newValue);
+            editPotentialBudgetForCategory(newValue);
             setAllocatedBudget(newAllocatedBudget);
         } else {
             // If the change would exceed the budget, set the slider to the maximum allowed value
             const maxAllowedValue = Number(sliderValue) + (Number(potentialTotalBudget) - Number(allocatedBudget));
             setSliderValue(maxAllowedValue);
+            editPotentialBudgetForCategory(newValue);
             setAllocatedBudget(potentialTotalBudget);
         }
     };
 
     useEffect(() => {
+            if (!hasMounted) {
+                setHasMounted(true);
+                return;
+            }
             setSliderValue(0);
             setAllocatedBudget(0);
     },[potentialTotalBudget]);

--- a/Web/src/context/budgetContext.jsx
+++ b/Web/src/context/budgetContext.jsx
@@ -10,7 +10,7 @@ export const BudgetProvider = ({ children, initTotalBudget }) => {
     const [categoryToBudgetDictionary, setCategoryToBudgetDictionary] = useState(null);
     const [potentialCategoryToBudgetDictionary, setPotentialCategoryToBudgetDictionary] = useState(null);
     const [newCategoryAdded, setNewCategoryAdded] = useState("a"); //this value is just going to be a string of a's, it exists to let the budget page know when to call the get budget details endpoint to avoid excessive or unnecessary api calls. Thought about making it true/false but thought that might be confusing and imply a different use 
-
+    const [budgetsEdited, setBudgetsEdited] = useState("a");
 
     const updateTotalBudget = (newTotal) => {
             if (newTotal < allocatedBudget){
@@ -34,6 +34,8 @@ export const BudgetProvider = ({ children, initTotalBudget }) => {
                 setPotentialCategoryToBudgetDictionary,
                 newCategoryAdded,
                 setNewCategoryAdded,
+                budgetsEdited,
+                setBudgetsEdited,
                 reset 
             }}>
                 {children}

--- a/Web/src/context/budgetContext.jsx
+++ b/Web/src/context/budgetContext.jsx
@@ -8,6 +8,7 @@ export const BudgetProvider = ({ children, initTotalBudget }) => {
     const [potentialTotalBudget, setPotentialTotalBudget] = useState(totalBudget.toString());
     const [reset, setReset] = useState(false);
     const [categoryToBudgetDictionary, setCategoryToBudgetDictionary] = useState(null);
+    const [potentialCategoryToBudgetDictionary, setPotentialCategoryToBudgetDictionary] = useState(null);
     const [newCategoryAdded, setNewCategoryAdded] = useState("a"); //this value is just going to be a string of a's, it exists to let the budget page know when to call the get budget details endpoint to avoid excessive or unnecessary api calls. Thought about making it true/false but thought that might be confusing and imply a different use 
 
 
@@ -29,6 +30,8 @@ export const BudgetProvider = ({ children, initTotalBudget }) => {
                 setPotentialTotalBudget,
                 categoryToBudgetDictionary,
                 setCategoryToBudgetDictionary,
+                potentialCategoryToBudgetDictionary,
+                setPotentialCategoryToBudgetDictionary,
                 newCategoryAdded,
                 setNewCategoryAdded,
                 reset 


### PR DESCRIPTION
---
name: Editing Budgets functionality 🚀
about: To allow user to edit budgets for categories and the total budget as well.
title: "[FEATURE] Editing Budgets functionality 🌟"
labels: ''
assignees: ''

---

**Related Issue(s)** 🔗
N/A

**Acceptance Test(s)** ✔️
1. cd into Web
2. npm run dev
3. cd into Server
4. npm start
5. navigate to budget page and click edit
6. mess around with the sliders and set the total budget to whatever you want
7. click apply and verify that the modal closes and the categories are displaying the budget totals you set 
8. verify that upon reopening the edit modal by clicking edit, the total is what you changed it to before clicking apply. 
9. verify also that the sliders are already set to the amounts they are currently at in the database

**Implementation Notes** 📝
BACKEND
changeBudgets.js:
- upserts new budget total and new budgets for categories and if it fails or succeeds lets the frontend know

getBudgetDetails.js:
- now also fetches the budget total instead of just the budgets for categories
- now converts budgets for categories response from db to dictionary before sending it to frontend

server.js:
- added change budgets route to it

FRONTEND:
ModalCategoryBudgetSlider.jsx:
- made reset useEffect not fire on mount
- replaced altering of current category to budget dictionary to use potential one instead

Budget.jsx:
- Added apply function functionality:
	- makes call to backend endpoint @change_budgets and feeds it users ID, supabase access token, the new category to budget dictionary and the new total budget
	- upon success it closes the modal and utilizes the setter for the variable called budgetsEdited, to trigger the useEffect that calls the backend endpoint @get_budget_details to retrieve the new budget values upon successful editing. 

budgetContext.jsx:
- Added some variables to hold on to edited states of things so I wouldn't have to worry about affecting the actual current state of said things

**Related PR(s)** 🔄
budget/backend-get-budget-details-endpoint : merging into this one because the pr is still up and this one would otherwise contain changes from it

**Checklist:** ✅
- [✅ ] My code follows the style guidelines of this project
- [ ✅] I have performed a self-review of my own code
- [ ✅] I have commented my code, particularly in hard-to-understand areas
- [ ✅] I have made corresponding changes to the documentation
- [ ✅] My changes generate no new warnings
- [ ✅] I have added tests that prove my fix is effective or that my feature works
- [ ✅] New and existing unit tests pass locally with my changes
- [ ✅] Any dependent changes have been merged and published in downstream modules

**Screenshots** 📸
![Screenshot 2025-02-06 160130](https://github.com/user-attachments/assets/f7f55628-8d99-4cf9-bc53-f038c4e3f6f3)
![Screenshot 2025-02-06 160123](https://github.com/user-attachments/assets/acedcf59-68de-49a5-b04f-0e0f947643a3)


**Additional Context** ➕
- User will be able to adjust the budget according to their preferred time window. Whether that be weekly, monthly, or yearly. The plan is for the frontend to adjust the category to budget dictionary values to be adjusted for weekly, as this is how all values will be assumed to be when stored in the database.
	- This also means that values will have to be adjusted when frontend receives budget details from backend if and only if the budget window is set to something other than weekly. 